### PR TITLE
feat: harden Supabase leaderboard flow and DB constraints

### DIFF
--- a/src/game/managers/LeaderboardManager.ts
+++ b/src/game/managers/LeaderboardManager.ts
@@ -9,11 +9,51 @@ export interface CloudLeaderboardEntry {
   created_at: string;
 }
 
+const SCORE_MIN = 0;
+const SCORE_MAX = 1_000_000_000;
+const WAVE_MIN = 0;
+const WAVE_MAX = 1_000_000;
+const PLAYER_NAME_MAX = 24;
+const MAP_ID_MAX = 64;
+const QUERY_TIMEOUT_MS = 8000;
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+function normalizePlayerName(name: string): string {
+  const normalized = name.trim().slice(0, PLAYER_NAME_MAX);
+  return normalized.length > 0 ? normalized : 'Anonymous';
+}
+
+function normalizeMapId(mapId: string): string {
+  const normalized = mapId.trim().slice(0, MAP_ID_MAX);
+  return normalized.length > 0 ? normalized : 'forest_path';
+}
+
+function withTimeoutSignal(timeoutMs: number): AbortSignal {
+  const controller = new AbortController();
+  setTimeout(() => controller.abort(), timeoutMs);
+  return controller.signal;
+}
+
 export async function submitScore(playerName: string, score: number, wave: number, mapId: string): Promise<boolean> {
+  const safePlayerName = normalizePlayerName(playerName);
+  const safeScore = clamp(Math.floor(score), SCORE_MIN, SCORE_MAX);
+  const safeWave = clamp(Math.floor(wave), WAVE_MIN, WAVE_MAX);
+  const safeMapId = normalizeMapId(mapId);
+
   try {
     const { error } = await supabase
       .from('leaderboard')
-      .insert({ player_name: playerName, score, wave, map_id: mapId });
+      .insert({
+        player_name: safePlayerName,
+        score: safeScore,
+        wave: safeWave,
+        map_id: safeMapId,
+      })
+      .abortSignal(withTimeoutSignal(QUERY_TIMEOUT_MS));
+
     return !error;
   } catch {
     return false;
@@ -21,15 +61,18 @@ export async function submitScore(playerName: string, score: number, wave: numbe
 }
 
 export async function fetchLeaderboard(mapId?: string, limit = 10): Promise<CloudLeaderboardEntry[]> {
+  const safeLimit = clamp(Math.floor(limit || 10), 1, 100);
+
   try {
     let query = supabase
       .from('leaderboard')
       .select('*')
       .order('score', { ascending: false })
-      .limit(limit);
+      .limit(safeLimit)
+      .abortSignal(withTimeoutSignal(QUERY_TIMEOUT_MS));
 
     if (mapId) {
-      query = query.eq('map_id', mapId);
+      query = query.eq('map_id', normalizeMapId(mapId));
     }
 
     const { data, error } = await query;

--- a/supabase/migrations/20260319174000_leaderboard_hardening.sql
+++ b/supabase/migrations/20260319174000_leaderboard_hardening.sql
@@ -1,0 +1,11 @@
+-- Harden leaderboard against obvious abuse / malformed inserts
+
+ALTER TABLE public.leaderboard
+  ADD CONSTRAINT leaderboard_player_name_length
+    CHECK (char_length(player_name) BETWEEN 1 AND 24),
+  ADD CONSTRAINT leaderboard_score_range
+    CHECK (score BETWEEN 0 AND 1000000000),
+  ADD CONSTRAINT leaderboard_wave_range
+    CHECK (wave BETWEEN 0 AND 1000000),
+  ADD CONSTRAINT leaderboard_map_id_length
+    CHECK (char_length(map_id) BETWEEN 1 AND 64);


### PR DESCRIPTION
## Résumé
Cette PR continue la migration post-Lovable en durcissant le flux leaderboard (front + DB):

- validation/normalisation côté front avant insert (`player_name`, `map_id`, `score`, `wave`)
- timeout explicite des requêtes Supabase dans le manager leaderboard
- migration SQL de durcissement (`CHECK constraints`) pour bloquer les inserts abusifs

## Détails techniques
- Nouveau fichier migration:
  - `supabase/migrations/20260319174000_leaderboard_hardening.sql`
- Modifs front:
  - `src/game/managers/LeaderboardManager.ts`

## Validation
- `npm run test` ✅
- `npm run build` ✅
- `supabase db push` ✅ (migration appliquée sur projet `bzateqbygxvvbaqcwhsk`)

## Issues liées
- #5
- #6
