### PR TITLE
feat: move Nidalee earlier and strengthen team wave XP

### DIFF
--- a/src/game/GameEngine.ts
+++ b/src/game/GameEngine.ts
@@ -690,7 +690,9 @@ export class GameEngine {
 
     for (const unit of placedUnits) {
       const participationBonus = supportPatterns.has(unit.config.attackPattern) ? 3 : 0;
-      this.awardUnitXp(unit.characterInstanceId, waveXp + participationBonus, `wave:${this.state.currentWave}`);
+      const totalWaveXp = waveXp + participationBonus;
+      this.awardUnitXp(unit.characterInstanceId, totalWaveXp, `wave:${this.state.currentWave}`);
+      this.floatingTextManager.spawn(unit.x, unit.y - 36, `WAVE XP +${totalWaveXp}`, '#93c5fd', 9);
     }
   }
 

--- a/src/game/data/unlockTreeData.ts
+++ b/src/game/data/unlockTreeData.ts
@@ -18,8 +18,17 @@ const RARITY_WEIGHT: Record<Rarity, number> = {
 };
 
 const STARTER_ORDER = ['garen', 'ashe', 'leona', 'teemo', 'lux'];
+const CURATED_EARLY_ORDER = ['garen', 'ashe', 'leona', 'teemo', 'lux', 'nidalee', 'caitlyn', 'leesin'];
 
 function compareCharacters(a: CharacterConfig, b: CharacterConfig): number {
+  const aCurated = CURATED_EARLY_ORDER.indexOf(a.id);
+  const bCurated = CURATED_EARLY_ORDER.indexOf(b.id);
+  if (aCurated !== -1 || bCurated !== -1) {
+    if (aCurated === -1) return 1;
+    if (bCurated === -1) return -1;
+    return aCurated - bCurated;
+  }
+
   const aStarter = STARTER_ORDER.indexOf(a.id);
   const bStarter = STARTER_ORDER.indexOf(b.id);
   if (aStarter !== -1 || bStarter !== -1) {

--- a/src/game/data/version.ts
+++ b/src/game/data/version.ts
@@ -1,1 +1,1 @@
-export const GAME_VERSION = '1.1.117';
+export const GAME_VERSION = '1.1.118';


### PR DESCRIPTION
## Résumé
- fait monter Nidalee plus tôt dans l'arbre pour l'anti-invisible dès le début
- renforce et rend visible le bonus d'XP de fin de vague pour toute l'équipe déployée
- met à jour le watermark en 1.1.118

## Validation
- npm test
- npm run build